### PR TITLE
feat: provide upstream example setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,12 @@ curl --location --request GET 'http://0.0.0.0:8080/api/v4/groups/<REPLACE_ME>/me
 ## API logs
 
 API Access logs are available for auditing in `/var/log/nginx/api_access.log`
+
+## Configuration with upstream
+
+For on-premises `GitLab` instances, an upstream configuration could be necessary.
+
+In order to use an upstream configuration with the proxy:
+
+- modify the `api_backends.conf` file in order to map the gitlab instance IP(s)
+- set the environment variable `GITLAB_URL` as follow: `<protocol><upstream_name>` e,g `http://example`

--- a/nginx-proxy/Dockerfile
+++ b/nginx-proxy/Dockerfile
@@ -1,20 +1,22 @@
 FROM nginx:1.19
 
-COPY nginx.conf /etc/nginx/nginx.conf
+COPY nginx.conf                            /etc/nginx/nginx.conf
 
-COPY gitlab-proxy.conf.template /etc/nginx/gitlab-proxy.conf.template
+COPY api_backends.conf                     /etc/nginx/api_backends.conf
 
-COPY api_json_errors.conf /etc/nginx/api_json_errors.conf
+COPY gitlab-proxy.conf.template            /etc/nginx/gitlab-proxy.conf.template
 
-COPY gitlab_api.conf /etc/nginx/gitlab_api.conf
+COPY api_json_errors.conf                  /etc/nginx/api_json_errors.conf
 
-COPY gitlab-api-routes/groups.conf /etc/nginx/gitlab_api_groups.conf
-COPY gitlab-api-routes/groups_hooks.conf /etc/nginx/gitlab_api_groups_hooks.conf
-COPY gitlab-api-routes/groups_labels.conf /etc/nginx/gitlab_api_groups_labels.conf
-COPY gitlab-api-routes/projects.conf /etc/nginx/gitlab_api_projects.conf
-COPY gitlab-api-routes/users.conf /etc/nginx/gitlab_api_users.conf
-COPY gitlab-api-routes/tags.conf /etc/nginx/gitlab_api_tags.conf
-COPY gitlab-api-routes/discussions.conf /etc/nginx/gitlab_api_discussions.conf
+COPY gitlab_api.conf                       /etc/nginx/gitlab_api.conf
+
+COPY gitlab-api-routes/groups.conf         /etc/nginx/gitlab_api_groups.conf
+COPY gitlab-api-routes/groups_hooks.conf   /etc/nginx/gitlab_api_groups_hooks.conf
+COPY gitlab-api-routes/groups_labels.conf  /etc/nginx/gitlab_api_groups_labels.conf
+COPY gitlab-api-routes/projects.conf       /etc/nginx/gitlab_api_projects.conf
+COPY gitlab-api-routes/users.conf          /etc/nginx/gitlab_api_users.conf
+COPY gitlab-api-routes/tags.conf           /etc/nginx/gitlab_api_tags.conf
+COPY gitlab-api-routes/discussions.conf    /etc/nginx/gitlab_api_discussions.conf
 COPY gitlab-api-routes/merge_requests.conf /etc/nginx/gitlab_api_merge_requests.conf
 
 COPY docker-entrypoint.sh /

--- a/nginx-proxy/api_backends.conf
+++ b/nginx-proxy/api_backends.conf
@@ -1,0 +1,7 @@
+upstream example {
+    zone example_service 64k;
+    
+    server 10.0.0.1:80;
+    server 10.0.0.2:80;
+    server 10.0.0.3:80;
+}

--- a/nginx-proxy/gitlab-proxy.conf.template
+++ b/nginx-proxy/gitlab-proxy.conf.template
@@ -1,3 +1,4 @@
+include api_backends.conf;
 include api_keys.conf;
 
 server {


### PR DESCRIPTION
closes #1 

Gives an example of setup with upstream for `on-premise` users.