### PR TITLE
feat: rather include the ip restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,16 +145,16 @@ docker run \
 ## Restricted access
 
 The proxy is preconfigured to only accept connections from Echoes IP addresses.
-If this turns out to be a problem for your particular deployment, comment the
-corresponding lines in the `gitlab-proxy.conf` file:
 
-```txt
-  # Restricted to Echoes IPs
-  # https://docs.echoeshq.com/echoes-ip-addresses
-  allow 34.91.37.106;
-  allow 34.90.193.154;
-  deny all;
 ```
+# gitlab-proxy.conf
+include proxy/ip_restriction.conf
+```
+
+If this turns out to be a problem for your particular deployment,
+this setting can be overriden by mounting another configuration file.
+
+`-v /tmp/ip_restriction.conf:/etc/nginx/proxy/ip_restriction.conf:ro`
 
 ## K8s deployment example
 

--- a/nginx-proxy/Dockerfile
+++ b/nginx-proxy/Dockerfile
@@ -2,8 +2,10 @@ FROM nginx:1.19
 
 COPY nginx.conf                            /etc/nginx/nginx.conf
 
-RUN mkdir /etc/nginx/backends
+RUN mkdir /etc/nginx/proxy
+COPY ip_restriction.conf                   /etc/nginx/proxy/ip_restriction.conf
 
+RUN mkdir /etc/nginx/backends
 COPY api_backends.conf                     /etc/nginx/api_backends/api_backends.conf
 
 COPY gitlab-proxy.conf                     /etc/nginx/gitlab-proxy.conf

--- a/nginx-proxy/gitlab-proxy.conf
+++ b/nginx-proxy/gitlab-proxy.conf
@@ -20,11 +20,7 @@ server {
     # ssl_ciphers          HIGH:!aNULL:!MD5;
     # ssl_protocols        TLSv1.2 TLSv1.3;
 
-    # Restricted to Echoes IPs
-    # https://docs.echoeshq.com/echoes-ip-addresses
-    allow 34.91.37.106;
-    allow 34.90.193.154;
-    deny all;
+    include proxy/ip_restriction.conf;
 
     # Required to resolve gitlab.com
     resolver 8.8.8.8 8.8.4.4 valid=1h; # use Google DNS and cache results for 1 hour

--- a/nginx-proxy/ip_restriction.conf
+++ b/nginx-proxy/ip_restriction.conf
@@ -1,0 +1,5 @@
+# Restricted to Echoes IPs
+# https://docs.echoeshq.com/echoes-ip-addresses
+allow 34.91.37.106;
+allow 34.90.193.154;
+deny all;


### PR DESCRIPTION
The IP restriction is now included in the proxy configuration file and no more hardcoded.
It has multiple benefits, one is that it will simplify unit testing of the proxy since it will require to be accessible by any IP. The test can then mount any configuration it pleases it do make on the IPs.