### PR TITLE
feat: add tests

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -35,7 +35,7 @@ jobs:
           npm install -g nginx-linter
           nginx-linter --include "nginx-proxy/**/*.conf"
 
-  docker:
+  test-proxy-image:
     runs-on: ubuntu-latest
 
     services:
@@ -68,20 +68,38 @@ jobs:
         run: |
           docker buildx imagetools inspect localhost:5000/gitlab-proxy:latest
 
-      - name: Prepare Docker Run
+      - name: Set up tests
+        id: set_up_tests
         working-directory: ./nginx-proxy
         run: |-
           cp .env.example /tmp/env
-          cp api_keys.conf.example /tmp/api_keys.conf
 
-      - name: Docker Run
+          echo "allow all;" > /tmp/ip_restriction.conf
+
+          private_token=$(openssl rand -base64 18)
+          echo ::set-output name=PRIVATE_TOKEN::${private_token}
+
+          gitlab_token=${{ secrets.GITLAB_TOKEN }}
+
+          {
+            echo '  map $http_PRIVATE_TOKEN $gitlab_token {'
+            echo '  default "";'
+            echo '  "'${private_token}'" "'${gitlab_token}'";'
+            echo '  }'
+          } >> /tmp/api_keys.conf
+
+      - name: Run gitlab-proxy
         run: |-
           docker run \
             -d \
             --env-file /tmp/env \
             -v /tmp/api_keys.conf:/etc/nginx/api_keys/api_keys.conf:ro \
+            -v /tmp/ip_restriction.conf:/etc/nginx/proxy/ip_restriction.conf:ro \
             -p 8080:80 localhost:5000/gitlab-proxy:latest
 
-      - name: Curl
+      - name: Tests
+        env:
+          PRIVATE_TOKEN: ${{ steps.set_up_tests.outputs.PRIVATE_TOKEN }}
         run: |-
-          curl -v http://0.0.0.0:8080
+          bash <(curl -s https://raw.githubusercontent.com/pgrange/bash_unit/master/install.sh)
+          ./bash_unit tests/*

--- a/tests/discussions.sh
+++ b/tests/discussions.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# TODO: put this in env var output from the set_up_tests CI job
+projectID=36541542
+mrID=13
+
+test_should_return_discussions() {
+    response=$(curl -sS --location --request GET 'http://0.0.0.0:8080/api/v4/projects/'${projectID}'/merge_requests/'${mrID}'/discussions' \
+    --header 'Content-Type: application/json' \
+    --header 'PRIVATE-TOKEN: '${PRIVATE_TOKEN}'')
+
+    assert_equals "a1c36c2f5f1ce4b62a7dd7f6f94f6ccf0deb5ff4" "$(echo ${response} | jq -r '.[0].id')"
+}

--- a/tests/groups.sh
+++ b/tests/groups.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# TODO: put this in env var output from the set_up_tests CI job
+groupID=53719108
+
+test_should_return_all_members() {
+    response=$(curl -sS --location --request GET 'http://0.0.0.0:8080/api/v4/groups/'${groupID}'/members/all' \
+    --header 'Content-Type: application/json' \
+    --header 'PRIVATE-TOKEN: '${PRIVATE_TOKEN}'')
+
+    assert_equals "2648022" "$(echo ${response} | jq -r '.[].id')"
+}
+
+test_should_return_members() {
+    response=$(curl -sS --location --request GET 'http://0.0.0.0:8080/api/v4/groups/'${groupID}'/members' \
+    --header 'Content-Type: application/json' \
+    --header 'PRIVATE-TOKEN: '${PRIVATE_TOKEN}'')
+
+    assert_equals "2648022" "$(echo ${response} | jq -r '.[].id')"
+}
+
+test_should_return_descendant_groups() {
+    response=$(curl -sS --location --request GET 'http://0.0.0.0:8080/api/v4/groups/'${groupID}'/descendant_groups' \
+    --header 'Content-Type: application/json' \
+    --header 'PRIVATE-TOKEN: '${PRIVATE_TOKEN}'')
+
+    assert_equals 0 "$(echo ${response} | jq length)"
+}
+
+test_should_return_projects() {
+    response=$(curl -sS --location --request GET 'http://0.0.0.0:8080/api/v4/groups/'${groupID}'/projects' \
+    --header 'Content-Type: application/json' \
+    --header 'PRIVATE-TOKEN: '${PRIVATE_TOKEN}'')
+
+    assert_equals 1 "$(echo ${response} | jq length)"
+    assert_equals "36541542" "$(echo ${response} | jq -r '.[0].id')"
+}
+
+test_should_return_projects() {
+    response=$(curl -sS --location --request GET 'http://0.0.0.0:8080/api/v4/groups/'${groupID}'/projects' \
+    --header 'Content-Type: application/json' \
+    --header 'PRIVATE-TOKEN: '${PRIVATE_TOKEN}'')
+
+    assert_equals 1 "$(echo ${response} | jq length)"
+    assert_equals "36541542" "$(echo ${response} | jq -r '.[0].id')"
+}
+
+test_should_return_group() {
+    response=$(curl -sS --location --request GET 'http://0.0.0.0:8080/api/v4/groups/'${groupID}'' \
+    --header 'Content-Type: application/json' \
+    --header 'PRIVATE-TOKEN: '${PRIVATE_TOKEN}'')
+
+    assert_equals "${groupID}" "$(echo ${response} | jq -r '.id')"
+}
+
+test_should_return_groups() {
+    response=$(curl -sS --location --request GET 'http://0.0.0.0:8080/api/v4/groups' \
+    --header 'Content-Type: application/json' \
+    --header 'PRIVATE-TOKEN: '${PRIVATE_TOKEN}'')
+
+    assert_equals "12045471" "$(echo ${response} | jq -r '.[0].id')"
+}

--- a/tests/groups_hooks.sh
+++ b/tests/groups_hooks.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# TODO: put this in env var output from the set_up_tests CI job
+groupID=53719108
+hookID=12852818
+
+test_should_return_all_hooks() {
+    response=$(curl -sS --location --request GET 'http://0.0.0.0:8080/api/v4/groups/'${groupID}'/hooks' \
+    --header 'Content-Type: application/json' \
+    --header 'PRIVATE-TOKEN: '${PRIVATE_TOKEN}'')
+
+    assert_equals ${hookID} "$(echo ${response} | jq -r '.[0].id')"
+}
+
+test_should_return_hooks_by_id() {
+    response=$(curl -sS --location --request GET 'http://0.0.0.0:8080/api/v4/groups/'${groupID}'/hooks/'${hookID}'' \
+    --header 'Content-Type: application/json' \
+    --header 'PRIVATE-TOKEN: '${PRIVATE_TOKEN}'')
+
+    assert_equals "404" "$(echo ${response} | jq -r '.status')"
+}

--- a/tests/groups_labels.sh
+++ b/tests/groups_labels.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+groupID=53719108
+
+test_should_return_labels() {
+    response=$(curl -sS --location --request GET 'http://0.0.0.0:8080/api/v4/groups/'${groupID}'/labels' \
+    --header 'Content-Type: application/json' \
+    --header 'PRIVATE-TOKEN: '${PRIVATE_TOKEN}'')
+
+    assert_equals 18 "$(echo ${response} | jq length)"
+    assert_equals "25315376" "$(echo ${response} | jq -r '.[0].id')"
+}

--- a/tests/merge_requests.sh
+++ b/tests/merge_requests.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# TODO: put this in env var output from the set_up_tests CI job
+groupID=53719108
+projectID=36541542
+mrID=13
+
+test_should_return_merge_requests() {
+    response=$(curl -sS --location --request GET 'http://0.0.0.0:8080/api/v4/groups/'${groupID}'/merge_requests' \
+    --header 'Content-Type: application/json' \
+    --header 'PRIVATE-TOKEN: '${PRIVATE_TOKEN}'')
+
+    assert_equals "36541542" "$(echo ${response} | jq -r '.[0].id')"
+}
+
+test_should_return_closes_issues() {
+    response=$(curl -sS --location --request GET 'http://0.0.0.0:8080/api/v4/projects/'${projectID}'/merge_requests/'${mrID}'/closes_issues' \
+    --header 'Content-Type: application/json' \
+    --header 'PRIVATE-TOKEN: '${PRIVATE_TOKEN}'')
+
+    assert_equals "109451069" "$(echo ${response} | jq -r '.[0].id')"
+}
+
+test_should_return_commits() {
+    response=$(curl -sS --location --request GET 'http://0.0.0.0:8080/api/v4/projects/'${projectID}'/merge_requests/'${mrID}'/commits' \
+    --header 'Content-Type: application/json' \
+    --header 'PRIVATE-TOKEN: '${PRIVATE_TOKEN}'')
+
+    assert_equals "5fe70de8936babbcfb10ee36c505356fe207df8a" "$(echo ${response} | jq -r '.[0].id')"
+}
+
+test_should_return_project_merge_request_by_id() {
+    response=$(curl -sS --location --request GET 'http://0.0.0.0:8080/api/v4/projects/'${projectID}'/merge_requests/'${mrID}'' \
+    --header 'Content-Type: application/json' \
+    --header 'PRIVATE-TOKEN: '${PRIVATE_TOKEN}'')
+
+    assert_equals "158333519" "$(echo ${response} | jq -r '.id')"
+}
+
+test_should_return_project_merge_requests() {
+    response=$(curl -sS --location --request GET 'http://0.0.0.0:8080/api/v4/projects/'${projectID}'/merge_requests' \
+    --header 'Content-Type: application/json' \
+    --header 'PRIVATE-TOKEN: '${PRIVATE_TOKEN}'')
+
+    assert_equals "158333519" "$(echo ${response} | jq -r '.[0].id')"
+}

--- a/tests/tags.sh
+++ b/tests/tags.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# TODO: put this in env var output from the set_up_tests CI job
+projectID=36541542
+
+test_should_return_tags() {
+    response=$(curl -sS --location --request GET 'http://0.0.0.0:8080/api/v4/projects/'${projectID}'/repository/tags' \
+    --header 'Content-Type: application/json' \
+    --header 'PRIVATE-TOKEN: '${PRIVATE_TOKEN}'')
+
+    assert_equals 0 "$(echo ${response} | jq length)"
+}

--- a/tests/users.sh
+++ b/tests/users.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# TODO: put this in env var output from the set_up_tests CI job
+userID=2648022
+
+test_should_return_user_by_id() {
+    response=$(curl -sS --location --request GET 'http://0.0.0.0:8080/api/v4/users/'${userID}'' \
+    --header 'Content-Type: application/json' \
+    --header 'PRIVATE-TOKEN: '${PRIVATE_TOKEN}'')
+
+    assert_equals "2648022" "$(echo ${response} | jq -r '.id')"
+}
+
+test_should_return_current_user() {
+    response=$(curl -sS --location --request GET 'http://0.0.0.0:8080/api/v4/user' \
+    --header 'Content-Type: application/json' \
+    --header 'PRIVATE-TOKEN: '${PRIVATE_TOKEN}'')
+
+    assert_equals "2648022" "$(echo ${response} | jq -r '.id')"
+}
+
+test_should_return_all_users() {
+    # on gitlab.com it is quite difficult to get a predictable result so
+    # we check the default page length only i.e 20.
+    response=$(curl -sS --location --request GET 'http://0.0.0.0:8080/api/v4/users' \
+    --header 'Content-Type: application/json' \
+    --header 'PRIVATE-TOKEN: '${PRIVATE_TOKEN}'')
+
+    assert_equals 20 "$(echo ${response} | jq length)"
+}


### PR DESCRIPTION
Basic tests are in place.
Another PR will follow to add more tests around the allowed methods i.e check that they return indeed a `404` for the expected HTTP verb.

The current tested GitLab group is not the final one that will be used. A proper setup is expected soon, as it may require some more specific data.

<img width="531" alt="Screenshot 2022-07-22 at 17 53 09" src="https://user-images.githubusercontent.com/1558229/180402558-b9815214-98fe-456d-81a3-0f013d765f7e.png">
