### PR TITLE
chore(CI): rm pr target triggers

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -7,8 +7,6 @@ on:
       - "*"
   pull_request:
     branches: [main]
-  pull_request_target:
-    types: [opened, synchronize, reopened, ready_for_review]
 
   workflow_dispatch:
 
@@ -18,13 +16,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        if: ${{ github.event_name != 'pull_request_target' }}
-
-      - name: Checkout PR
-        if: ${{ github.event_name == 'pull_request_target' }}
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
This PR removes any references to `pull_request_target` for simplicity in CI.