### PR TITLE
fix: forward query parameters

### DIFF
--- a/nginx-proxy/echoes.conf.template
+++ b/nginx-proxy/echoes.conf.template
@@ -1,5 +1,5 @@
 # Add the proxy's version to the HTTP headers
-add_header X-Echoes-GitLab-Proxy-Version v0.1.0 always;
+add_header X-Echoes-GitLab-Proxy-Version v0.1.1 always;
 
 # Set the global variables from environment
 set $GITLAB_API_URL ${GITLAB_URL};

--- a/nginx-proxy/gitlab-api-routes/discussions.conf
+++ b/nginx-proxy/gitlab-api-routes/discussions.conf
@@ -1,7 +1,7 @@
 location ~ /api/v4/projects/(.*)/merge_requests/(.*)/discussions {
     limit_except POST PUT DELETE {
         # For requests that *are not* POST, PUT or DELETE
-        proxy_pass $GITLAB_API_URL/api/v4/projects/$1/merge_requests/$2/discussions;
+        proxy_pass $GITLAB_API_URL/api/v4/projects/$1/merge_requests/$2/discussions$is_args$args;
     }
     return 404;
 }

--- a/nginx-proxy/gitlab-api-routes/groups.conf
+++ b/nginx-proxy/gitlab-api-routes/groups.conf
@@ -1,7 +1,7 @@
 location ~ /api/v4/groups/(.*)/members/all {
     limit_except POST PUT DELETE {
         # For requests that *are not* POST, PUT or DELETE
-        proxy_pass $GITLAB_API_URL/api/v4/groups/$1/members/all;
+        proxy_pass $GITLAB_API_URL/api/v4/groups/$1/members/all$is_args$args;
     }
     return 404;
 }
@@ -9,7 +9,7 @@ location ~ /api/v4/groups/(.*)/members/all {
 location ~ /api/v4/groups/(.*)/members {
     limit_except POST PUT DELETE {
         # For requests that *are not* POST, PUT or DELETE
-        proxy_pass $GITLAB_API_URL/api/v4/groups/$1/members;
+        proxy_pass $GITLAB_API_URL/api/v4/groups/$1/members$is_args$args;
     }
     return 404;
 }
@@ -17,7 +17,7 @@ location ~ /api/v4/groups/(.*)/members {
 location ~ /api/v4/groups/(.*)/descendant_groups {
     limit_except POST PUT DELETE {
         # For requests that *are not* POST, PUT or DELETE
-        proxy_pass $GITLAB_API_URL/api/v4/groups/$1/descendant_groups;
+        proxy_pass $GITLAB_API_URL/api/v4/groups/$1/descendant_groups$is_args$args;
     }
     return 404;
 }
@@ -25,7 +25,7 @@ location ~ /api/v4/groups/(.*)/descendant_groups {
 location ~ /api/v4/groups/(.*)/projects {
     limit_except POST PUT DELETE {
         # For requests that *are not* POST, PUT or DELETE
-        proxy_pass $GITLAB_API_URL/api/v4/groups/$1/projects;
+        proxy_pass $GITLAB_API_URL/api/v4/groups/$1/projects$is_args$args;
     }
     return 404;
 }
@@ -33,7 +33,7 @@ location ~ /api/v4/groups/(.*)/projects {
 location ~ /api/v4/groups/(.*) {
     limit_except POST PUT DELETE {
         # For requests that *are not* POST, PUT or DELETE
-        proxy_pass $GITLAB_API_URL/api/v4/groups/$1;
+        proxy_pass $GITLAB_API_URL/api/v4/groups/$1$is_args$args;
     }
     return 404;
 }
@@ -41,7 +41,7 @@ location ~ /api/v4/groups/(.*) {
 location /api/v4/groups {
     # workaround the "proxy_pass cannot have URI part in location given by regular
     # expression inside "limit_except" block" error
-    rewrite ^ /api/v4/groups$1;
+    rewrite ^ /api/v4/groups$1$is_args$args;
     limit_except POST PUT DELETE {
         # For requests that *are not* POST, PUT or DELETE
         proxy_pass $GITLAB_API_URL;

--- a/nginx-proxy/gitlab-api-routes/groups_hooks.conf
+++ b/nginx-proxy/gitlab-api-routes/groups_hooks.conf
@@ -1,7 +1,7 @@
 location ~ /api/v4/groups/(.*)/hooks/(.*) {
     limit_except GET POST {
         # For requests that *are not* GET (HEAD) or POST
-        proxy_pass $GITLAB_API_URL/api/v4/groups/$1/hooks/$2;
+        proxy_pass $GITLAB_API_URL/api/v4/groups/$1/hooks/$2$is_args$args;
     }
     return 404;
 }
@@ -9,7 +9,7 @@ location ~ /api/v4/groups/(.*)/hooks/(.*) {
 location ~ /api/v4/groups/(.*)/hooks {
     limit_except DELETE {
         # For requests that *are not* DELETE
-        proxy_pass $GITLAB_API_URL/api/v4/groups/$1/hooks;
+        proxy_pass $GITLAB_API_URL/api/v4/groups/$1/hooks$is_args$args;
     }
     return 404;
 }

--- a/nginx-proxy/gitlab-api-routes/groups_labels.conf
+++ b/nginx-proxy/gitlab-api-routes/groups_labels.conf
@@ -1,8 +1,8 @@
 location ~ /api/v4/groups/(.*)/labels/(.*) {
-    proxy_pass $GITLAB_API_URL/api/v4/groups/$1/labels/$2;
+    proxy_pass $GITLAB_API_URL/api/v4/groups/$1/labels/$2$is_args$args;
 }
 
 # Support deprecated endpoint
 location ~ /api/v4/groups/(.*)/labels {
-    proxy_pass $GITLAB_API_URL/api/v4/groups/$1/labels;
+    proxy_pass $GITLAB_API_URL/api/v4/groups/$1/labels$is_args$args;
 }

--- a/nginx-proxy/gitlab-api-routes/merge_requests.conf
+++ b/nginx-proxy/gitlab-api-routes/merge_requests.conf
@@ -1,7 +1,7 @@
 location ~ /api/v4/groups/(.*)/merge_requests {
     limit_except POST PUT DELETE {
         # For requests that *are not* POST, PUT or DELETE
-        proxy_pass $GITLAB_API_URL/api/v4/groups/$1/merge_requests;
+        proxy_pass $GITLAB_API_URL/api/v4/groups/$1/merge_requests$is_args$args;
     }
     return 404;
 }
@@ -9,7 +9,7 @@ location ~ /api/v4/groups/(.*)/merge_requests {
 location ~ /api/v4/projects/(.*)/merge_requests/(.*)/closes_issues {
     limit_except POST PUT DELETE {
         # For requests that *are not* POST, PUT or DELETE
-        proxy_pass $GITLAB_API_URL/api/v4/projects/$1/merge_requests/$2/closes_issues;
+        proxy_pass $GITLAB_API_URL/api/v4/projects/$1/merge_requests/$2/closes_issues$is_args$args;
     }
     return 404;
 }
@@ -17,7 +17,7 @@ location ~ /api/v4/projects/(.*)/merge_requests/(.*)/closes_issues {
 location ~ /api/v4/projects/(.*)/merge_requests/(.*)/commits {
     limit_except POST PUT DELETE {
         # For requests that *are not* POST, PUT or DELETE
-        proxy_pass $GITLAB_API_URL/api/v4/projects/$1/merge_requests/$2/commits;
+        proxy_pass $GITLAB_API_URL/api/v4/projects/$1/merge_requests/$2/commits$is_args$args;
     }
     return 404;
 }
@@ -25,7 +25,7 @@ location ~ /api/v4/projects/(.*)/merge_requests/(.*)/commits {
 location ~ /api/v4/projects/(.*)/merge_requests/(.*) {
     limit_except POST PUT DELETE {
         # For requests that *are not* POST, PUT or DELETE
-        proxy_pass $GITLAB_API_URL/api/v4/projects/$1/merge_requests/$2;
+        proxy_pass $GITLAB_API_URL/api/v4/projects/$1/merge_requests/$2$is_args$args;
     }
     return 404;
 }
@@ -33,7 +33,7 @@ location ~ /api/v4/projects/(.*)/merge_requests/(.*) {
 location ~ /api/v4/projects/(.*)/merge_requests {
     limit_except POST PUT DELETE {
         # For requests that *are not* POST, PUT or DELETE
-        proxy_pass $GITLAB_API_URL/api/v4/projects/$1/merge_requests;
+        proxy_pass $GITLAB_API_URL/api/v4/projects/$1/merge_requests$is_args$args;
     }
     return 404;
 }

--- a/nginx-proxy/gitlab-api-routes/projects.conf
+++ b/nginx-proxy/gitlab-api-routes/projects.conf
@@ -1,7 +1,7 @@
 location ~ /api/v4/projects/(.*)/repository/commits/(.*) {
     limit_except POST PUT DELETE {
         # For requests that *are not* POST, PUT or DELETE
-        proxy_pass $GITLAB_API_URL/api/v4/projects/$1/repository/commits/$2;
+        proxy_pass $GITLAB_API_URL/api/v4/projects/$1/repository/commits/$2$is_args$args;
     }
     return 404;
 }
@@ -9,7 +9,7 @@ location ~ /api/v4/projects/(.*)/repository/commits/(.*) {
 location ~ /api/v4/projects/(.*)/users {
     limit_except POST PUT DELETE {
         # For requests that *are not* POST, PUT or DELETE
-        proxy_pass $GITLAB_API_URL/api/v4/projects/$1/users;
+        proxy_pass $GITLAB_API_URL/api/v4/projects/$1/users$is_args$args;
     }
     return 404;
 }
@@ -17,7 +17,7 @@ location ~ /api/v4/projects/(.*)/users {
 location ~ /api/v4/projects/(.*) {
     limit_except POST PUT DELETE {
         # For requests that *are not* POST, PUT or DELETE
-        proxy_pass $GITLAB_API_URL/api/v4/projects/$1;
+        proxy_pass $GITLAB_API_URL/api/v4/projects/$1$is_args$args;
     }
     return 404;
 }

--- a/nginx-proxy/gitlab-api-routes/tags.conf
+++ b/nginx-proxy/gitlab-api-routes/tags.conf
@@ -1,7 +1,7 @@
 location ~ /api/v4/projects/(.*)/repository/tags {
     limit_except POST PUT DELETE {
         # For requests that *are not* POST, PUT or DELETE
-        proxy_pass $GITLAB_API_URL/api/v4/projects/$1/repository/tags;
+        proxy_pass $GITLAB_API_URL/api/v4/projects/$1/repository/tags$is_args$args;
     }
     return 404;
 }

--- a/nginx-proxy/gitlab-api-routes/users.conf
+++ b/nginx-proxy/gitlab-api-routes/users.conf
@@ -1,7 +1,7 @@
 location ~ /api/v4/users/(.*) {
     limit_except POST PUT DELETE {
         # For requests that *are not* POST, PUT or DELETE
-        proxy_pass $GITLAB_API_URL/api/v4/users/$1;
+        proxy_pass $GITLAB_API_URL/api/v4/users/$1$is_args$args;
     }
     return 404;
 }
@@ -9,7 +9,7 @@ location ~ /api/v4/users/(.*) {
 location /api/v4/users {
     # workaround the "proxy_pass cannot have URI part in location given by regular
     # expression inside "limit_except" block" error
-    rewrite ^ /api/v4/users$1;
+    rewrite ^ /api/v4/users$1$is_args$args;
     limit_except POST PUT DELETE {
         # For requests that *are not* POST, PUT or DELETE
         proxy_pass $GITLAB_API_URL;
@@ -18,7 +18,7 @@ location /api/v4/users {
 }
 
 location /api/v4/user {
-    rewrite ^ /api/v4/user$1;
+    rewrite ^ /api/v4/user$1$is_args$args;
     limit_except POST PUT DELETE {
         # For requests that *are not* POST, PUT or DELETE
         proxy_pass $GITLAB_API_URL;

--- a/tests/groups_labels.sh
+++ b/tests/groups_labels.sh
@@ -8,4 +8,18 @@ test_should_return_labels() {
 
     doHave=$(has "${response}" "id" "26133076")
     assert_equals "${doHave}" true
+
+    # There are more than 20 labels on the group.
+    # Since no pagination was specified, it returns the default page size i.e 20.
+    assert_equals 20 "$(echo "${response}" | jq length)"
+}
+
+test_should_return_paginated_labels() {
+    # page 1
+    response=$(doRequest "GET" "${PROXY_BASE_PATH}/groups/${GROUP_ID}/labels?page=1&per_page=5")
+    assert_equals 5 "$(echo "${response}" | jq length)"
+
+    # page 2
+    response=$(doRequest "GET" "${PROXY_BASE_PATH}/groups/${GROUP_ID}/labels?page=2&per_page=5")
+    assert_equals 5 "$(echo "${response}" | jq length)"
 }

--- a/tests/merge_requests.sh
+++ b/tests/merge_requests.sh
@@ -12,6 +12,12 @@ test_should_return_merge_requests() {
     assert_equals "${doHave}" true
 }
 
+test_should_return_paginated_merge_requests() {
+    response=$(doRequest "GET" "${PROXY_BASE_PATH}/groups/${GROUP_ID}/merge_requests?page=2&per_page=2")
+    assert_equals 2 "$(echo "${response}" | jq length)"
+}
+
+
 test_should_disallow_merge_requests_POST_PUT_DELETE() {
     response=$(doRequest "POST" "${PROXY_BASE_PATH}/groups/${GROUP_ID}/merge_requests")
 
@@ -76,7 +82,7 @@ test_should_disallow_project_merge_requests_byID_POST_PUT_DELETE() {
 test_should_return_project_merge_requests() {
     response=$(doRequest "GET" "${PROXY_BASE_PATH}/projects/${PROJECT_ID}/merge_requests")
 
-    assert_equals 3 "$(echo "${response}" | jq length)"
+    assert_equals 6 "$(echo "${response}" | jq length)"
 
     doHave=$(has "${response}" "iid" "${mrID}")
     assert_equals "${doHave}" true


### PR DESCRIPTION
This PR fixes the fact that query parameters were not forwarded by the proxy. Which is very useful especially for pagination!
It also adds a test to make sure the forwarding works as expected.