### PR TITLE
feat(namespaces): add the GET endpoint to list namespaces

### DIFF
--- a/nginx-proxy/Dockerfile
+++ b/nginx-proxy/Dockerfile
@@ -21,6 +21,7 @@ COPY gitlab-api-routes/users.conf          /etc/nginx/gitlab_api_users.conf
 COPY gitlab-api-routes/tags.conf           /etc/nginx/gitlab_api_tags.conf
 COPY gitlab-api-routes/discussions.conf    /etc/nginx/gitlab_api_discussions.conf
 COPY gitlab-api-routes/merge_requests.conf /etc/nginx/gitlab_api_merge_requests.conf
+COPY gitlab-api-routes/namespaces.conf     /etc/nginx/gitlab_api_namespaces.conf
 
 RUN mkdir /etc/nginx/api_keys
 

--- a/nginx-proxy/echoes.conf.template
+++ b/nginx-proxy/echoes.conf.template
@@ -1,5 +1,5 @@
 # Add the proxy's version to the HTTP headers
-add_header X-Echoes-GitLab-Proxy-Version v0.1.2 always;
+add_header X-Echoes-GitLab-Proxy-Version v0.2.0 always;
 
 # Set the global variables from environment
 set $GITLAB_API_URL ${GITLAB_URL};

--- a/nginx-proxy/gitlab-api-routes/namespaces.conf
+++ b/nginx-proxy/gitlab-api-routes/namespaces.conf
@@ -1,0 +1,7 @@
+location ~ /api/v4/namespaces {
+    limit_except POST PUT DELETE {
+        # For requests that *are not* POST, PUT or DELETE
+        proxy_pass $GITLAB_API_URL/api/v4/namespaces$is_args$args;
+    }
+    return 404;
+}

--- a/nginx-proxy/gitlab_api.conf
+++ b/nginx-proxy/gitlab_api.conf
@@ -17,6 +17,7 @@ location /api/v4/ {
     include gitlab_api_groups.conf;
     include gitlab_api_projects.conf;
     include gitlab_api_users.conf;
+    include gitlab_api_namespaces.conf;
 
     return 404; # Catch-all
 }

--- a/tests/groups.sh
+++ b/tests/groups.sh
@@ -42,7 +42,10 @@ test_should_disallow_members_POST_PUT_DELETE() {
 
 test_should_return_descendant_groups() {
     response=$(doRequest "GET" "${PROXY_BASE_PATH}/groups/${GROUP_ID}/descendant_groups")
-    assert_equals 0 "$(echo "${response}" | jq length)"
+    assert_equals 1 "$(echo "${response}" | jq length)"
+
+    doHave=$(has "${response}" "id" "58527609")
+    assert_equals "${doHave}" true
 }
 
 test_should_disallow_descendant_groups_POST_PUT_DELETE() {

--- a/tests/namespaces.sh
+++ b/tests/namespaces.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# includes
+. ./helpers.sh
+
+test_should_return_namespaces() {
+    response=$(doRequest "GET" "${PROXY_BASE_PATH}/namespaces")
+
+    doHave=$(has "${response}" "id" "12045471")
+    assert_equals "${doHave}" true
+}
+
+test_should_return_paginated_namespaces() {
+    response=$(doRequest "GET" "${PROXY_BASE_PATH}/namespaces?page=1&per_page=2")
+    assert_equals 2 "$(echo "${response}" | jq length)"
+}
+
+test_should_disallow_namespaces_POST_PUT_DELETE() {
+    response=$(doRequest "POST" "${PROXY_BASE_PATH}/namespaces")
+
+    assert_equals 404 "$(echo "${response}" | jq -r '.status')"
+
+    response=$(doRequest "PUT" "${PROXY_BASE_PATH}/namespaces")
+
+    assert_equals 404 "$(echo "${response}" | jq -r '.status')"
+
+    response=$(doRequest "DELETE" "${PROXY_BASE_PATH}/namespaces")
+
+    assert_equals 404 "$(echo "${response}" | jq -r '.status')"
+}


### PR DESCRIPTION
This PR adds the GET endpoint in order to list namespaces: https://docs.gitlab.com/ee/api/namespaces.html#list-namespaces

Also it improves one test about listing descendant groups. To make sure it actually returns "something" the GitLab instance has been updated to include a subgroup.

It also bumps the version to `v0.2.0`.