### PR TITLE
fix: support URL-encoded project path for MR

### DIFF
--- a/nginx-proxy/echoes.conf.template
+++ b/nginx-proxy/echoes.conf.template
@@ -1,5 +1,5 @@
 # Add the proxy's version to the HTTP headers
-add_header X-Echoes-GitLab-Proxy-Version v0.2.0 always;
+add_header X-Echoes-GitLab-Proxy-Version v0.2.1 always;
 
 # Set the global variables from environment
 set $GITLAB_API_URL ${GITLAB_URL};

--- a/nginx-proxy/gitlab-api-routes/merge_requests.conf
+++ b/nginx-proxy/gitlab-api-routes/merge_requests.conf
@@ -23,9 +23,14 @@ location ~ /api/v4/projects/(.*)/merge_requests/(.*)/commits {
 }
 
 location ~ /api/v4/projects/(.*)/merge_requests/(.*) {
+    # The project can be accessed from its ID or URL-encoded path.
+    # In very few cases Echoes uses the URL-encoded path.
+    # Nginx needs to re-encode the decoded part in order to satisfy the GitLab API expectations.
+    # Using the rewrite directive is the way to do so.
+    rewrite ^ /api/v4/projects/$1/merge_requests/$2$is_args$args;
     limit_except POST DELETE {
         # For requests that *are not* POST or DELETE
-        proxy_pass $GITLAB_API_URL/api/v4/projects/$1/merge_requests/$2$is_args$args;
+        proxy_pass $GITLAB_API_URL;
     }
     return 404;
 }

--- a/tests/merge_requests.sh
+++ b/tests/merge_requests.sh
@@ -60,8 +60,15 @@ test_should_disallow_groups_merge_requests_commits_POST_PUT_DELETE() {
 
 test_should_return_project_merge_request_by_id() {
     response=$(doRequest "GET" "${PROXY_BASE_PATH}/projects/${PROJECT_ID}/merge_requests/${mrID}")
-
     assert_equals "${mrID}" "$(echo "${response}" | jq -r '.iid')"
+
+    # Test project access via an URL-encoded path
+    response=$(doRequest "GET" "${PROXY_BASE_PATH}/projects/echoes-hq%2Fgitlab-proxy-test/merge_requests/${mrID}")
+    assert_equals "${mrID}" "$(echo "${response}" | jq -r '.iid')"
+
+    # Test project access via a non URL-encoded path returns a 404 (from GitLab)
+    response=$(doRequest "GET" "${PROXY_BASE_PATH}/projects/echoes-hq/gitlab-proxy-test/merge_requests/${mrID}")
+    assert_equals "404 Not Found" "$(echo "${response}" | jq -r '.error')"
 }
 
 test_should_disallow_project_merge_requests_byID_POST_DELETE() {


### PR DESCRIPTION
Adds support to access projects' MR via an URL-encoded path.

Bump version to `v0.2.1`