### PR TITLE
feat: return 200 for calls targetting API root

### DIFF
--- a/nginx-proxy/Dockerfile
+++ b/nginx-proxy/Dockerfile
@@ -22,6 +22,7 @@ COPY gitlab-api-routes/tags.conf           /etc/nginx/gitlab_api_tags.conf
 COPY gitlab-api-routes/discussions.conf    /etc/nginx/gitlab_api_discussions.conf
 COPY gitlab-api-routes/merge_requests.conf /etc/nginx/gitlab_api_merge_requests.conf
 COPY gitlab-api-routes/namespaces.conf     /etc/nginx/gitlab_api_namespaces.conf
+COPY gitlab-api-routes/root.conf           /etc/nginx/gitlab_api_root.conf
 
 RUN mkdir /etc/nginx/api_keys
 

--- a/nginx-proxy/echoes.conf.template
+++ b/nginx-proxy/echoes.conf.template
@@ -1,5 +1,5 @@
 # Add the proxy's version to the HTTP headers
-add_header X-Echoes-GitLab-Proxy-Version v0.2.1 always;
+add_header X-Echoes-GitLab-Proxy-Version v0.3.0 always;
 
 # Set the global variables from environment
 set $GITLAB_API_URL ${GITLAB_URL};

--- a/nginx-proxy/gitlab-api-routes/root.conf
+++ b/nginx-proxy/gitlab-api-routes/root.conf
@@ -1,0 +1,3 @@
+location = /api/v4/ {
+    return 200;
+}

--- a/nginx-proxy/gitlab_api.conf
+++ b/nginx-proxy/gitlab_api.conf
@@ -19,5 +19,10 @@ location /api/v4/ {
     include gitlab_api_users.conf;
     include gitlab_api_namespaces.conf;
 
+    # Some SDK perform a first API call on init in order to get the rate limit headers.
+    # The call is a GET targetting the API root /api/v4/.
+    # Therefore the proxy returns a 200 in order to avoid noise in error logs.
+    include gitlab_api_root.conf;
+
     return 404; # Catch-all
 }

--- a/tests/helpers.sh
+++ b/tests/helpers.sh
@@ -52,3 +52,15 @@ function doRequest() {
 
     echo "${response}"
 }
+
+
+function doRequestI() {
+    url=$1
+    method=$2
+
+    response=$(curl -I --location --request "${url}" "${method}" \
+    --header 'Content-Type: application/json' \
+    --header 'PRIVATE-TOKEN: '"${PRIVATE_TOKEN}"'' | grep "HTTP/1.1 200 OK")
+
+    echo "${response}"
+}

--- a/tests/root.sh
+++ b/tests/root.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# includes
+. ./helpers.sh
+
+test_should_return_status_ok() {
+    response=$(doRequestI "GET" "${PROXY_BASE_PATH}/")
+    assert_matches "HTTP/1.1 200 OK" "${response}"
+
+    response=$(doRequestI "POST" "${PROXY_BASE_PATH}/")
+    assert_matches "HTTP/1.1 200 OK" "${response}"
+
+    response=$(doRequestI "PUT" "${PROXY_BASE_PATH}/")
+    assert_matches "HTTP/1.1 200 OK" "${response}"
+
+    response=$(doRequestI "DELETE" "${PROXY_BASE_PATH}/")
+    assert_matches "HTTP/1.1 200 OK" "${response}"
+}


### PR DESCRIPTION
Echoes is using an SDK that perform a first call to the API root in order to obtain the rate limit headers.
Until now the proxy would return a `404` as per the GitLab API would also do. However it is preferable to return a `200` in order to limit the noise in error logs.