### PR TITLE
feat: add resource label events route

### DIFF
--- a/nginx-proxy/gitlab-api-routes/merge_requests.conf
+++ b/nginx-proxy/gitlab-api-routes/merge_requests.conf
@@ -6,6 +6,14 @@ location ~ /api/v4/groups/(.*)/merge_requests {
     return 404;
 }
 
+location ~ /api/v4/projects/(.*)/merge_requests/(.*)/resource_label_events {
+    limit_except POST PUT DELETE {
+        # For requests that *are not* POST, PUT or DELETE
+        proxy_pass $GITLAB_API_URL/api/v4/projects/$1/merge_requests/$2/resource_label_events$is_args$args;
+    }
+    return 404;
+}
+
 location ~ /api/v4/projects/(.*)/merge_requests/(.*)/closes_issues {
     limit_except POST PUT DELETE {
         # For requests that *are not* POST, PUT or DELETE

--- a/nginx-proxy/gitlab-api-routes/projects.conf
+++ b/nginx-proxy/gitlab-api-routes/projects.conf
@@ -14,6 +14,14 @@ location ~ /api/v4/projects/(.*)/users {
     return 404;
 }
 
+location ~ /api/v4/projects/(.*)/issues/(.*)/resource_label_events {
+    limit_except POST PUT DELETE {
+        # For requests that *are not* POST, PUT or DELETE
+        proxy_pass $GITLAB_API_URL/api/v4/projects/$1/issues/$2/resource_label_events$is_args$args;
+    }
+    return 404;
+}
+
 location ~ /api/v4/projects/(.*) {
     limit_except POST PUT DELETE {
         # For requests that *are not* POST, PUT or DELETE

--- a/tests/issues.sh
+++ b/tests/issues.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# includes
+. ./helpers.sh
+
+issueID=1
+
+test_should_return_project_issues_resource_label_events() {
+    response=$(doRequest "GET" "${PROXY_BASE_PATH}/projects/${PROJECT_ID}/issues/${issueID}/resource_label_events")
+
+    assert_equals 0 "$(echo "${response}" | jq length)"
+}
+
+test_should_disallow_projects_issues_resource_label_events_POST_PUT_DELETE() {
+    response=$(doRequest "POST" "${PROXY_BASE_PATH}/projects/${PROJECT_ID}/issues/${issueID}/resource_label_events")
+
+    assert_equals 404 "$(echo "${response}" | jq -r '.status')"
+
+    response=$(doRequest "PUT" "${PROXY_BASE_PATH}/projects/${PROJECT_ID}/issues/${issueID}/resource_label_events")
+
+    assert_equals 404 "$(echo "${response}" | jq -r '.status')"
+
+    response=$(doRequest "DELETE" "${PROXY_BASE_PATH}/projects/${PROJECT_ID}/issues/${issueID}/resource_label_events")
+
+    assert_equals 404 "$(echo "${response}" | jq -r '.status')"
+}

--- a/tests/merge_requests.sh
+++ b/tests/merge_requests.sh
@@ -103,3 +103,23 @@ test_should_disallow_projects_merge_requests_POST_PUT_DELETE() {
 
     assert_equals 404 "$(echo "${response}" | jq -r '.status')"
 }
+
+test_should_return_project_merge_requests_resource_label_events() {
+    response=$(doRequest "GET" "${PROXY_BASE_PATH}/projects/${PROJECT_ID}/merge_requests/${mrID}/resource_label_events")
+
+    assert_equals 0 "$(echo "${response}" | jq length)"
+}
+
+test_should_disallow_projects_merge_requests_resource_label_events_POST_PUT_DELETE() {
+    response=$(doRequest "POST" "${PROXY_BASE_PATH}/projects/${PROJECT_ID}/merge_requests/${mrID}/resource_label_events")
+
+    assert_equals 404 "$(echo "${response}" | jq -r '.status')"
+
+    response=$(doRequest "PUT" "${PROXY_BASE_PATH}/projects/${PROJECT_ID}/merge_requests/${mrID}/resource_label_events")
+
+    assert_equals 404 "$(echo "${response}" | jq -r '.status')"
+
+    response=$(doRequest "DELETE" "${PROXY_BASE_PATH}/projects/${PROJECT_ID}/merge_requests/${mrID}/resource_label_events")
+
+    assert_equals 404 "$(echo "${response}" | jq -r '.status')"
+}


### PR DESCRIPTION
Adds the `resource_label_events` route for issues and MRs.
https://docs.gitlab.com/ee/api/resource_label_events.html#issues