### PR TITLE
feat: add personal_access_tokens route

### DIFF
--- a/nginx-proxy/Dockerfile
+++ b/nginx-proxy/Dockerfile
@@ -22,6 +22,7 @@ COPY gitlab-api-routes/tags.conf           /etc/nginx/gitlab_api_tags.conf
 COPY gitlab-api-routes/discussions.conf    /etc/nginx/gitlab_api_discussions.conf
 COPY gitlab-api-routes/merge_requests.conf /etc/nginx/gitlab_api_merge_requests.conf
 COPY gitlab-api-routes/namespaces.conf     /etc/nginx/gitlab_api_namespaces.conf
+COPY gitlab-api-routes/personal_access_tokens.conf /etc/nginx/gitlab_api_personal_access_tokens.conf
 COPY gitlab-api-routes/root.conf           /etc/nginx/gitlab_api_root.conf
 
 RUN mkdir /etc/nginx/api_keys

--- a/nginx-proxy/echoes.conf.template
+++ b/nginx-proxy/echoes.conf.template
@@ -1,5 +1,5 @@
 # Add the proxy's version to the HTTP headers
-add_header X-Echoes-GitLab-Proxy-Version v0.4.0 always;
+add_header X-Echoes-GitLab-Proxy-Version v0.5.0 always;
 
 # Set the global variables from environment
 set $GITLAB_API_URL ${GITLAB_URL};

--- a/nginx-proxy/gitlab-api-routes/personal_access_tokens.conf
+++ b/nginx-proxy/gitlab-api-routes/personal_access_tokens.conf
@@ -1,0 +1,7 @@
+location ~ /api/v4/personal_access_tokens/self {
+    limit_except POST PUT DELETE {
+        # For requests that *are not* POST, PUT or DELETE
+        proxy_pass $GITLAB_API_URL/api/v4/personal_access_tokens/self$is_args$args;
+    }
+    return 404;
+}

--- a/nginx-proxy/gitlab_api.conf
+++ b/nginx-proxy/gitlab_api.conf
@@ -18,6 +18,7 @@ location /api/v4/ {
     include gitlab_api_projects.conf;
     include gitlab_api_users.conf;
     include gitlab_api_namespaces.conf;
+    include gitlab_api_personal_access_tokens.conf;
 
     # Some SDK perform a first API call on init in order to get the rate limit headers.
     # The call is a GET targetting the API root /api/v4/.

--- a/tests/personal_access_tokens.sh
+++ b/tests/personal_access_tokens.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# includes
+. ./helpers.sh
+
+name="Test gitlab-proxy "
+
+test_should_return_token_description() {
+    response=$(doRequest "GET" "${PROXY_BASE_PATH}/personal_access_tokens/self")
+    assert_equals "${name}" "$(echo "${response}" | jq -r '.name')"
+}
+
+test_should_disallow_token_description_POST_PUT_DELETE() {
+    response=$(doRequest "POST" "${PROXY_BASE_PATH}/personal_access_tokens/self")
+    assert_equals 404 "$(echo "${response}" | jq -r '.status')"
+
+    response=$(doRequest "PUT" "${PROXY_BASE_PATH}/personal_access_tokens/self")
+    assert_equals 404 "$(echo "${response}" | jq -r '.status')"
+
+    response=$(doRequest "DELETE" "${PROXY_BASE_PATH}/personal_access_tokens/self")
+    assert_equals 404 "$(echo "${response}" | jq -r '.status')"
+}


### PR DESCRIPTION
We added the ability to check on a token to make sure of its validity.
https://docs.gitlab.com/ee/api/personal_access_tokens.html#using-a-request-header