### PR TITLE
feat(projects-hooks): authorize creating webhook for project

### DIFF
--- a/nginx-proxy/Dockerfile
+++ b/nginx-proxy/Dockerfile
@@ -16,6 +16,7 @@ COPY gitlab_api.conf                       /etc/nginx/gitlab_api.conf
 COPY gitlab-api-routes/groups.conf         /etc/nginx/gitlab_api_groups.conf
 COPY gitlab-api-routes/groups_hooks.conf   /etc/nginx/gitlab_api_groups_hooks.conf
 COPY gitlab-api-routes/groups_labels.conf  /etc/nginx/gitlab_api_groups_labels.conf
+COPY gitlab-api-routes/projects_hooks.conf /etc/nginx/gitlab_api_projects_hooks.conf
 COPY gitlab-api-routes/projects.conf       /etc/nginx/gitlab_api_projects.conf
 COPY gitlab-api-routes/users.conf          /etc/nginx/gitlab_api_users.conf
 COPY gitlab-api-routes/tags.conf           /etc/nginx/gitlab_api_tags.conf

--- a/nginx-proxy/echoes.conf.template
+++ b/nginx-proxy/echoes.conf.template
@@ -1,5 +1,5 @@
 # Add the proxy's version to the HTTP headers
-add_header X-Echoes-GitLab-Proxy-Version v0.5.0 always;
+add_header X-Echoes-GitLab-Proxy-Version v0.6.0 always;
 
 # Set the global variables from environment
 set $GITLAB_API_URL ${GITLAB_URL};

--- a/nginx-proxy/gitlab-api-routes/projects_hooks.conf
+++ b/nginx-proxy/gitlab-api-routes/projects_hooks.conf
@@ -1,0 +1,15 @@
+location ~ /api/v4/projects/(.*)/hooks/(.*) {
+    limit_except GET POST {
+        # For requests that *are not* GET (HEAD) or POST
+        proxy_pass $GITLAB_API_URL/api/v4/projects/$1/hooks/$2$is_args$args;
+    }
+    return 404;
+}
+
+location ~ /api/v4/projects/(.*)/hooks {
+    limit_except DELETE {
+        # For requests that *are not* DELETE
+        proxy_pass $GITLAB_API_URL/api/v4/projects/$1/hooks$is_args$args;
+    }
+    return 404;
+}

--- a/nginx-proxy/gitlab_api.conf
+++ b/nginx-proxy/gitlab_api.conf
@@ -15,6 +15,7 @@ location /api/v4/ {
     include gitlab_api_discussions.conf;
     include gitlab_api_merge_requests.conf;
     include gitlab_api_groups.conf;
+    include gitlab_api_projects_hooks.conf;
     include gitlab_api_projects.conf;
     include gitlab_api_users.conf;
     include gitlab_api_namespaces.conf;

--- a/tests/projects_hooks.sh
+++ b/tests/projects_hooks.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# includes
+. ./helpers.sh
+
+setup_suite() {
+    # create a test hook
+    response=$(curl -sS --location -d '{"url":"http://foo.barr.com"}' --request POST "${PROXY_BASE_PATH}/projects/${PROJECT_ID}/hooks" \
+    --header 'Content-Type: application/json' \
+    --header 'PRIVATE-TOKEN: '"${PRIVATE_TOKEN}"'')
+
+    hookID=$(echo "${response}" | jq -r '.id')
+    export hookID
+}
+
+test_should_return_all_hooks() {
+    # list hooks
+    response=$(doRequest "GET" "${PROXY_BASE_PATH}/projects/${PROJECT_ID}/hooks")
+
+    # verify the hook is in the list
+    doHave=$(has "${response}" "id" "${hookID}")
+    assert_equals "${doHave}" true
+}
+
+test_should_disallow_hooks_GETbyID_POSTbyID() {
+    response=$(doRequest "GET" "${PROXY_BASE_PATH}/projects/${PROJECT_ID}/hooks/${hookID}")
+    assert_equals 404 "$(echo "${response}" | jq -r '.status')"
+
+    response=$(doRequest "POST" "${PROXY_BASE_PATH}/projects/${PROJECT_ID}/hooks/${hookID}")
+    assert_equals 404 "$(echo "${response}" | jq -r '.status')"
+}
+
+teardown_suite() {
+    # delete the test hook
+    response=$(doRequest "DELETE" "${PROXY_BASE_PATH}/projects/${PROJECT_ID}/hooks/${hookID}")
+}


### PR DESCRIPTION
The recent change in the gitlab installation flow was not compatible with the proxy. The route to post a webhook on a project was not authorized.