### PR TITLE
chore: update tests

### DIFF
--- a/tests/groups_labels.sh
+++ b/tests/groups_labels.sh
@@ -6,7 +6,7 @@
 test_should_return_labels() {
     response=$(doRequest "GET" "${PROXY_BASE_PATH}/groups/${GROUP_ID}/labels")
 
-    doHave=$(has "${response}" "id" "26133076")
+    doHave=$(has "${response}" "id" "26982298")
     assert_equals "${doHave}" true
 
     # There are more than 20 labels on the group.

--- a/tests/personal_access_tokens.sh
+++ b/tests/personal_access_tokens.sh
@@ -3,7 +3,7 @@
 # includes
 . ./helpers.sh
 
-name="Test gitlab-proxy "
+name="GitLab proxy tests"
 
 test_should_return_token_description() {
     response=$(doRequest "GET" "${PROXY_BASE_PATH}/personal_access_tokens/self")


### PR DESCRIPTION
Update tests to account for expired PAT for the service account used in tests.
